### PR TITLE
Remove deprecated ActiveRecord calls

### DIFF
--- a/lib/ucb_orgs/concerns/org_unit.rb
+++ b/lib/ucb_orgs/concerns/org_unit.rb
@@ -1,14 +1,14 @@
 module UcbOrgs
   module Concerns
     module OrgUnit
-      extend ActiveSupport::Concern
+      extend ::ActiveSupport::Concern
 
       module ClassMethods
 
         def load_from_csv(csv_filename)
           CSV.foreach(csv_filename, headers: true) do |row|
             org_unit = UcbOrgs::OrgUnit.find_or_create_by(code: row['CODE'])
-            org_unit.update_attributes(
+            org_unit.update(
               name:  row['NAME'],
               level:  row['LEVEL'].to_i,
               level_2:  row['LEVEL_2'],

--- a/lib/ucb_orgs/syncer.rb
+++ b/lib/ucb_orgs/syncer.rb
@@ -61,7 +61,7 @@ module UcbOrgs
     def sync_org(ldap_org_entry)
       code = nb_to_string(ldap_org_entry.code)
       UcbOrgs::OrgUnit.find_or_initialize_by(code: code).tap do |org|
-        org.update_attributes!(
+        org.update!(
           code: code,
           name: nb_to_string(ldap_org_entry.name),
           level: ldap_org_entry.level,

--- a/ucb_orgs.gemspec
+++ b/ucb_orgs.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ucb_ldap", "~> 3.0"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rails", "> 5.0"
+  spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
This gem was using `update_attributes` which had been deprecated and has been removed from newer versions of Rails